### PR TITLE
[slap] Ignore control codes

### DIFF
--- a/slap.py
+++ b/slap.py
@@ -14,7 +14,10 @@ from willie.module import commands
 def slap(willie, trigger):
     """.slap <target> - Slaps <target>"""
     text = trigger.group().split()
-    text[1] = re.sub(r"\x1f|\x02|\x12|\x0f|\x16|\x03(?:\d{1,2}(?:,\d{1,2})?)?", '', text[1])
+    try:
+        text[1] = re.sub(r"\x1f|\x02|\x12|\x0f|\x16|\x03(?:\d{1,2}(?:,\d{1,2})?)?", '', text[1])
+    except IndexError:
+        return
     if len(text) < 2 or text[1].startswith('#'):
         return
     if text[1] == willie.nick:


### PR DESCRIPTION
Do not allow control codes in the input to foil checking of whether willie.config.admins contains the trigger or target. Replaces all known control codes with an empty string using regex.

This could also be possibly related to embolalia/willie#462
