### PR TITLE
[twit] Decode HTML entities in tweets

### DIFF
--- a/twit.py
+++ b/twit.py
@@ -10,13 +10,19 @@ from __future__ import print_function
 import tweepy
 import time
 import re
-import htmlentitydefs
 from sopel.config import ConfigurationError
 from sopel import tools
 from sopel.module import rule
 import sys
 if sys.version_info.major < 3:
     str = unicode
+
+try:
+    import html
+except ImportError:
+    import HTMLParser
+    html = HTMLParser.HTMLParser()
+unescape = html.unescape
 
 
 def configure(config):
@@ -60,29 +66,6 @@ def format_thousands(integer):
 def tweet_url(status):
     """Returns a URL to Twitter for the given status object"""
     return 'https://twitter.com/' + status.user.screen_name + '/status/' + status.id_str
-
-def unescape(text):
-    """Returns the input with HTML entities decoded to characters"""
-    """from http://effbot.org/zone/re-sub.htm#unescape-html"""
-    def fixup(m):
-        text = m.group(0)
-        if text[:2] == "&#":
-            # character reference
-            try:
-                if text[:3] == "&#x":
-                    return unichr(int(text[3:-1], 16))
-                else:
-                    return unichr(int(text[2:-1]))
-            except ValueError:
-                pass
-        else:
-            # named entity
-            try:
-                text = unichr(htmlentitydefs.name2codepoint[text[1:-1]])
-            except KeyError:
-                pass
-        return text # leave as is
-    return re.sub("&#?\w+;", fixup, text)
 
 @rule('.*twitter.com\/(\S*)\/status\/([\d]+).*')
 def gettweet(sopel, trigger, found_match=None):


### PR DESCRIPTION
No more &amp;lt; instead of <, etc.

Seemed most portable to just include a function to do this, as other methods I found depended on either Python 2.x or 3 stuff.
