### PR TITLE
[twit] Python 2 should use unicode(), not str()

### DIFF
--- a/twit.py
+++ b/twit.py
@@ -12,6 +12,9 @@ import re
 from willie.config import ConfigurationError
 from willie import tools
 from willie.module import rule
+import sys
+if sys.version_info.major < 3:
+    str = unicode
 
 def configure(config):
     """
@@ -77,7 +80,7 @@ def gettweet(willie, trigger, found_match=None):
                     statusnum = int(parts[1]) - 1
                 status = api.user_timeline(twituser)[statusnum]
         twituser = '@' + status.user.screen_name
-        willie.say(twituser + ": " + unicode(status.text) + ' <' + tweet_url(status) + '>')
+        willie.say(twituser + ": " + str(status.text) + ' <' + tweet_url(status) + '>')
     except:
         willie.reply("You have inputted an invalid user.")
 gettweet.commands = ['twit']


### PR DESCRIPTION
The twit module was tripping on users with Unicode characters in their profile data, and Python 2.x distinguishes between `str` and `unicode` as different types (yes, yes, upgrade to Py3, etc.).

I _think_ this is a decent way of doing it, but please tell me if there's a better way to fix this and keep compatibility with both Py2 & Py3.
