### PR TITLE
Update imgur.py to prevent error on configure

### DIFF
--- a/imgur.py
+++ b/imgur.py
@@ -53,7 +53,7 @@ def configure(config):
     """
 
     if config.option('Configure Imgur? (You will need to register at https://api.imgur.com/oauth2/addclient)', False):
-        config.interactive.add('imgur', 'client_id', 'Client ID')
+        config.interactive_add('imgur', 'client_id', 'Client ID')
 
 def setup(bot):
     """


### PR DESCRIPTION
`interactive.add` to `interactive_add` to prevent an error with `interactive` not being defined when configuring modules saying `y` to configure the imgur module.
