### PR TITLE
avoid helpbot crash if misconfigured

### DIFF
--- a/helpbot.py
+++ b/helpbot.py
@@ -18,7 +18,11 @@ def configure(config):
     | -------- | ------- | ------- |
     | channel | #help | Enter the channel HelpBot should moderate |
     """
-    config.interactive_add('helpbot', 'channel', "Enter the channel HelpBot should moderate", '#help')
+    config.interactive_add('helpbot', 'channel', "Enter the channel HelpBot should moderate", None)
+
+def setup(bot):
+    if not bot.config.helpbot.channel:
+        raise ConfigurationError('Helpbot module not configured')
 
 @event('JOIN')
 @rule(r'.*')


### PR DESCRIPTION
without this patch, if the helpbot channel would be set to None, it
would fail with:

```
AttributeError: 'NoneType' object has no attribute 'lower' (file /usr/lib/python2.7/dist-packages/willie/tools.py, line 362, in _lower)
```

the modules in -extras should be enabled by default so this makes
"None" a valid value that makes the module be ignored. we also default
to None so that, by default, the helpbot module doesn't do anything
