### PR TITLE
use requests instead of willie's web library for SNI support

### DIFF
--- a/bookie.py
+++ b/bookie.py
@@ -252,7 +252,8 @@ def api(bot, trigger, func, data=None):
 
 def api_bmark(bot, trigger, found_match=None, extra=None):
     url = found_match or trigger
-    bytes = web.get(url)
+    # XXX: we use requests instead of web.get because web.get doesn't support SNI
+    bytes = requests.get(url).text
     # XXX: needs a patch to the URL module
     title = find_title(content=bytes)
     if title is None:


### PR DESCRIPTION
without requests, https://blog.matan.me/ would return an SSL
verification error:

ssl.CertificateError: hostname 'blog.matan.me' doesn't match either of 'ssl2000.cloudflare.com', 'cloudflare.com', '*.cloudflare.com' (file "/usr/lib/python3.4/ssl.py", line 284, in match_hostname)

I had expected python3 to support SNI, but it doesn't seem to be the
case.

you can also compare the output of:

```
gnutls-cli blog.matan.me
gnutls-cli --disable-sni blog.matan.me
```

...to reproduce the "non-SNI" problem from gnutls-cli.
