### PR TITLE
Fix slap's reference to "admins" config section

### DIFF
--- a/slap.py
+++ b/slap.py
@@ -11,7 +11,7 @@ from sopel.module import commands
 
 
 @commands('slap', 'slaps')
-def slap(sopel, trigger):
+def slap(bot, trigger):
     """.slap <target> - Slaps <target>"""
     text = trigger.group().split()
     if len(text) < 2:
@@ -21,13 +21,13 @@ def slap(sopel, trigger):
         return
     if text[1] == 'me' or text[1] == 'myself':
         text[1] = trigger.nick
-    if text[1] == sopel.nick:
-        if (trigger.nick not in sopel.config.admins):
+    if text[1] == bot.nick:
+        if (trigger.nick not in bot.config.core.admins):
             text[1] = trigger.nick
         else:
             text[1] = 'itself'
-    if text[1] in sopel.config.admins:
-        if (trigger.nick not in sopel.config.admins):
+    if text[1] in bot.config.core.admins:
+        if (trigger.nick not in bot.config.core.admins):
             text[1] = trigger.nick
     verb = random.choice(('slaps', 'kicks', 'destroys', 'annihilates', 'punches', 'roundhouse kicks', 'pwns', 'owns'))
-    sopel.write(['PRIVMSG', trigger.sender, ' :\x01ACTION', verb, text[1], '\x01'])
+    bot.write(['PRIVMSG', trigger.sender, ' :\x01ACTION', verb, text[1], '\x01'])


### PR DESCRIPTION
Fix reference to "admins" config section (which is in core)
Reference instance as "bot" instead of "sopel" for clarity (this is the convention used in bundled modules)
